### PR TITLE
fix: rename driver variable in video router

### DIFF
--- a/src/videos/routers/videos.router.ts
+++ b/src/videos/routers/videos.router.ts
@@ -18,11 +18,11 @@ videosRouter
     })
     .get("/:id", validateIdParam, async (req: express.Request, res: express.Response) => {
         const id: number = (res.locals as any).id;
-        const driver = db.videos.find((video: Video) => video.id === id);
-        if (!driver) {
+        const video = db.videos.find((v: Video) => v.id === id);
+        if (!video) {
             res.status(HttpStatus.NotFound).send("No such video");
         }
-        res.status(200).send(driver);
+        res.status(200).send(video);
     })
     .post("/", async (req: express.Request, res: express.Response) => {
         const body = req.body as Partial<CreateVideoInputModel>;


### PR DESCRIPTION
## Summary
- rename local `driver` variable in GET /:id handler to `video`

## Testing
- `pnpm lint` *(fails: ESLint couldn't find configuration)*
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm jest` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e943bd2c8321bb34493418e4e343