### PR TITLE
Add video API end-to-end tests

### DIFF
--- a/__tests__/videos.e2e.test.ts
+++ b/__tests__/videos.e2e.test.ts
@@ -1,0 +1,72 @@
+import request from 'supertest';
+import express from 'express';
+import { setupApp } from '../src/setup-app';
+import { db } from '../src/db/in-memory.db';
+import { ResolutionsEnum } from '../src/videos/types/video';
+import { HttpStatus } from '../src/core/types/http-statuses';
+
+const app = setupApp(express());
+
+describe('Videos API', () => {
+  beforeEach(() => {
+    db.videos = [];
+  });
+
+  it('greets on root route', async () => {
+    await request(app).get('/').expect(HttpStatus.Ok).expect('Hello world!');
+  });
+
+  it('handles full CRUD flow', async () => {
+    await request(app).get('/api/videos').expect(HttpStatus.Ok, []);
+
+    const createData = {
+      title: 'test video',
+      author: 'author',
+      availableResolutions: [ResolutionsEnum.P720],
+    };
+    const createRes = await request(app)
+      .post('/api/videos')
+      .send(createData)
+      .expect(HttpStatus.Created);
+    const id = createRes.body.id;
+
+    await request(app).get(`/api/videos/${id}`).expect(HttpStatus.Ok);
+
+    const updateData = {
+      title: 'updated',
+      author: 'new author',
+      availableResolutions: [ResolutionsEnum.P720],
+      canBeDownloaded: false,
+      minAgeRestriction: 16,
+      publicationDate: new Date().toISOString(),
+    };
+    await request(app)
+      .put(`/api/videos/${id}`)
+      .send(updateData)
+      .expect(HttpStatus.NoContent);
+
+    const updated = await request(app)
+      .get(`/api/videos/${id}`)
+      .expect(HttpStatus.Ok);
+    expect(updated.body).toMatchObject({
+      title: updateData.title,
+      author: updateData.author,
+      canBeDownloaded: updateData.canBeDownloaded,
+      minAgeRestriction: updateData.minAgeRestriction,
+      availableResolutions: updateData.availableResolutions,
+      publicationDate: updateData.publicationDate,
+    });
+
+    await request(app).delete(`/api/videos/${id}`).expect(HttpStatus.NoContent);
+
+    await request(app).get(`/api/videos/${id}`).expect(HttpStatus.NotFound);
+  });
+
+  it('validates input on create', async () => {
+    const res = await request(app)
+      .post('/api/videos')
+      .send({})
+      .expect(HttpStatus.BadRequest);
+    expect(res.body.errorsMessages.length).toBeGreaterThan(0);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/src/videos/routers/videos.router.ts
+++ b/src/videos/routers/videos.router.ts
@@ -20,15 +20,15 @@ videosRouter
         const id: number = (res.locals as any).id;
         const driver = db.videos.find((video: Video) => video.id === id);
         if (!driver) {
-            res.status(HttpStatus.NotFound).send("No such video");
+            return res.status(HttpStatus.NotFound).send("No such video");
         }
-        res.status(200).send(driver);
+        return res.status(HttpStatus.Ok).send(driver);
     })
     .post("/", async (req: express.Request, res: express.Response) => {
         const body = req.body as Partial<CreateVideoInputModel>;
         const errors = validateCreateVideoInput(body);
         if (errors.length > 0) {
-            res.status(HttpStatus.BadRequest).send(createErrorMessages(errors))
+            return res.status(HttpStatus.BadRequest).send(createErrorMessages(errors));
         }
 
         const nowIso = new Date().toISOString();
@@ -44,7 +44,7 @@ videosRouter
         };
 
         db.videos.push(newVideo);
-        res.status(HttpStatus.Created).send(newVideo);
+        return res.status(HttpStatus.Created).send(newVideo);
     })
     .put("/:id", validateIdParam, async (req: express.Request, res: express.Response) => {
         const id: number = (res.locals as any).id;
@@ -56,7 +56,7 @@ videosRouter
         const body = req.body as Partial<UpdateVideoInputModel>;
         const errors = validateUpdateVideoInput(body);
         if (errors.length > 0) {
-           res.status(HttpStatus.BadRequest).send(createErrorMessages(errors));
+           return res.status(HttpStatus.BadRequest).send(createErrorMessages(errors));
         }
 
         video.title = body.title!.trim();
@@ -66,7 +66,7 @@ videosRouter
         video.minAgeRestriction = body.minAgeRestriction ?? null;
         video.publicationDate = body.publicationDate!;
 
-        res.send(HttpStatus.NoContent);
+        return res.sendStatus(HttpStatus.NoContent);
     })
     .delete("/:id", validateIdParam, async (req: express.Request, res: express.Response) => {
         const id: number = (res.locals as any).id;


### PR DESCRIPTION
## Summary
- add Jest config for TypeScript
- cover video API with end-to-end tests
- fix router to return proper statuses when errors occur

## Testing
- `pnpm jest`


------
https://chatgpt.com/codex/tasks/task_e_68a4e664841c8321b66611b99f4e2561